### PR TITLE
Lints and rustfmt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,14 +77,10 @@ fn main(){
     let mut exe_path = std::path::PathBuf::new();
     let reader = std::io::BufReader::new(cargo_cmd.stdout.take().unwrap());
     for message in cargo_metadata::Message::parse_stream(reader) {
-        match message.unwrap() {
-            Message::CompilerArtifact(artifact) => {
-                match artifact.executable {
-                    Some(n) => { exe_path = n; },
-                    _ => ()
-                }
-            },
-            _ => () // Unknown message
+        if let Message::CompilerArtifact(artifact) = message.unwrap() {
+            if let Some(n) = artifact.executable {
+                exe_path = n;
+            }
         }
     }
 


### PR DESCRIPTION
This PR has two commits:

- b73cb27 which fixes the clippy lints (`cargo clippy`) by using `let Some` destructor instead of `match`
- fc2553a which runs `cargo fmt` (the standard [rustfmt](https://github.com/rust-lang/rustfmt))

Please to let me know if you feel like this PR should not be here: I just felt like bringing it up because I personally like it when repos conform to community's standard but obviously not everyone feels the same way :)