### PR TITLE
Extend CLI to allow consuming prebuilt app

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,10 @@ use serde_derive::Deserialize;
 #[derive(Debug, Deserialize)]
 struct NanosMetadata {
     curve: String,
+    path: String,
     flags: String,
     icon: String,
+    name: Option<String>
 }
 
 fn main() {
@@ -122,13 +124,14 @@ fn main() {
     // create manifest
     let file = fs::File::create(&app_json).unwrap();
     let json = json!({
-        "name": &this_pkg.name,
+        "name": this_metadata.name.as_ref().unwrap_or(&this_pkg.name),
         "version": &this_pkg.version,
         "icon": &this_metadata.icon,
         "targetId": "0x31100004",
         "flags": this_metadata.flags,
         "derivationPath": {
-            "curves": [ this_metadata.curve ]
+            "curves": [ this_metadata.curve ],
+            "paths": [ this_metadata.path ]
         },
         "binary": hex_file,
         "dataSize": data_size


### PR DESCRIPTION
I will use both these flags together with our Nix build pipeline.

We will still read the config from the Cargo.toml, because that is the
metadata source of truth, but the ELF exe will already be prebuilt and
in a read-only location. We'll therefore have the json and hex
side-by-side, and then move then together to the output location.

Now that the CLI is more complex, I took the opportunity to convert it
to the declarative style of Clap --- it's really nice!

Contains #4