### PR TITLE
unified build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Cargo-ledger
 
-Builds a NanoS App and outputs an `app.json` manifest file for [ledgerctl](https://github.com/LedgerHQ/ledgerctl)
+Builds a Nano App and outputs a JSON manifest file that can be used by [ledgerctl](https://github.com/LedgerHQ/ledgerctl) to install an application directly.
+
+In order to build for Nano S, Nano X, and Nano S Plus, [custom target files](https://docs.rust-embedded.org/embedonomicon/custom-target.html) are used. They can be found at the root of the [Rust SDK](https://github.com/LedgerHQ/ledger-nanos-sdk/).
 
 ## Installation
 
@@ -21,7 +23,28 @@ cargo install --path .
 Note that `cargo`'s dependency resolver may behave differently when installing, and you may end up with errors.
 In order to fix those and force usage of the versions specified in the tagged `Cargo.lock`, append `--locked` to the above commands.
 
+### Setting up custom targets
+
+The preferred method is to have all custom target files (`nanos.json`, `nanox.json` and `nanosplus.json`) in a separate folder, and set an environment variable called `LEDGER_TARGETS` pointing to this folder.
+
+`cargo ledger` will check for this environment variable (or default to "" if it is empty) to fetch the current target specification.
+
 ## Usage
 
-`cargo ledger`
-`cargo ledger load`
+
+```
+cargo ledger nanos
+cargo ledger nanox
+cargo ledger nanosplus
+```
+
+Loading can optionally be performed by appending `--load` or `-l` to the command.
+
+By default, this program will attempt to build the current program with in `release` mode (full command: `cargo build -Zbuild-std -Zbuild-std-features=compiler-builtins-mem --release --target=nanos.json --message-format=json`)
+
+
+Arguments can be passed to modify this behaviour after inserting a `--` like so:
+
+```
+cargo ledger nanos --load -- --features one -Z unstable-options --out-dir ./output/
+```

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,61 @@
+use std::env;
+use std::fs;
+use std::io;
+use std::io::Write;
+use std::process::Command;
+
+pub fn retrieve_data_size(file: &std::path::Path) -> Result<u64, io::Error> {
+    let buffer = fs::read(&file)?;
+    let elf = goblin::elf::Elf::parse(&buffer).unwrap();
+
+    let mut nvram_data = 0;
+    let mut envram_data = 0;
+    for s in elf.syms.iter() {
+        let symbol_name = elf.strtab.get(s.st_name);
+        let name = symbol_name.unwrap().unwrap();
+        match name {
+            "_nvram_data" => nvram_data = s.st_value,
+            "_envram_data" => envram_data = s.st_value,
+            _ => (),
+        }
+    }
+    Ok(envram_data - nvram_data)
+}
+
+pub fn export_binary(elf_path: &std::path::Path, dest_bin: &std::path::Path) {
+    let objcopy = env::var_os("CARGO_TARGET_THUMBV6M_NONE_EABI_OBJCOPY")
+        .unwrap_or_else(|| "arm-none-eabi-objcopy".into());
+
+    Command::new(objcopy)
+        .arg(&elf_path)
+        .arg(&dest_bin)
+        .args(&["-O", "ihex"])
+        .output()
+        .expect("Objcopy failed");
+
+    let size = env::var_os("CARGO_TARGET_THUMBV6M_NONE_EABI_SIZE")
+        .unwrap_or_else(|| "arm-none-eabi-size".into());
+
+    // print some size info while we're here
+    let out = Command::new(size)
+        .arg(&elf_path)
+        .output()
+        .expect("Size failed");
+
+    io::stdout().write_all(&out.stdout).unwrap();
+    io::stderr().write_all(&out.stderr).unwrap();
+}
+
+pub fn install_with_ledgerctl(
+    dir: &std::path::Path,
+    app_json: &std::path::Path,
+) {
+    let out = Command::new("ledgerctl")
+        .current_dir(dir)
+        .args(&["install", "-f", app_json.to_str().unwrap()])
+        .output()
+        .expect("fail");
+
+    io::stdout().write_all(&out.stdout).unwrap();
+    io::stderr().write_all(&out.stderr).unwrap();
+}


### PR DESCRIPTION
This PR handles other targets than the Nano S, following the work on [this branch of the SDK](https://github.com/LedgerHQ/ledger-nanos-sdk/tree/unified_build).

It also simplifies the command logic and allows passing arbitrary flags to the subsequent `cargo build` command.
Loading is now just a flag and not a separate subcommand.