### PR TITLE
Added a possible launch via speculos

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,8 @@ enum MainCommand {
         device: Device,
         #[clap(short, long)]
         load: bool,
+        #[clap(short, long)]
+        speculos: bool,
         #[clap(last = true)]
         remaining_args: Vec<String>,
     },
@@ -82,12 +84,13 @@ fn main() {
         Err(_) => String::new(),
     };
 
-    let (device, is_load, remaining_args) = match cli.command {
+    let (device, is_load, is_speculos, remaining_args) = match cli.command {
         MainCommand::Ledger {
             device: d,
             load: a,
+            speculos: s,
             remaining_args: r,
-        } => (d, a, r),
+        } => (d, a, s, r),
     };
 
     let device_str = <Device as Into<&str>>::into(device);
@@ -189,5 +192,9 @@ fn main() {
 
     if is_load {
         install_with_ledgerctl(current_dir, &app_json);
+    }
+
+    if is_speculos {
+        run_in_speculos(current_dir, &exe_path);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,6 @@ fn main() {
     }
 
     if is_speculos {
-        run_in_speculos(current_dir, &exe_path);
+        run_in_speculos(current_dir, &device_str, &exe_path);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,3 +59,15 @@ pub fn install_with_ledgerctl(
     io::stdout().write_all(&out.stdout).unwrap();
     io::stderr().write_all(&out.stderr).unwrap();
 }
+
+pub fn run_in_speculos(dir: &std::path::Path, exe_path: &std::path::Path) {
+    println!("{}", exe_path.to_str().unwrap());
+    let out = Command::new("speculos.py")
+        .current_dir(dir)
+        .args(&["--display", "qt", "-k", "2.0", exe_path.to_str().unwrap()])
+        .output()
+        .expect("fail");
+
+    io::stdout().write_all(&out.stdout).unwrap();
+    io::stderr().write_all(&out.stderr).unwrap();
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,11 +60,23 @@ pub fn install_with_ledgerctl(
     io::stderr().write_all(&out.stderr).unwrap();
 }
 
-pub fn run_in_speculos(dir: &std::path::Path, exe_path: &std::path::Path) {
+pub fn run_in_speculos(
+    dir: &std::path::Path,
+    model: &str,
+    exe_path: &std::path::Path,
+) {
     println!("{}", exe_path.to_str().unwrap());
     let out = Command::new("speculos.py")
         .current_dir(dir)
-        .args(&["--display", "qt", "-k", "2.0", exe_path.to_str().unwrap()])
+        .args(&[
+            "--model",
+            model,
+            "--display",
+            "qt",
+            "-k",
+            "2.0",
+            exe_path.to_str().unwrap(),
+        ])
         .output()
         .expect("fail");
 


### PR DESCRIPTION
Since there is now support for all devices, it became necessary to store all .json for building.

https://github.com/LedgerHQ/rust-app/pull/18#issuecomment-1246610496

Generally I want to see `cargo-ledger` as a universal tool for building and testing the application. This is a small contribution in this direction to run the built application in Speculos.