### PR TITLE
Download and install custom target JSONs automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,23 +3,6 @@
 version = 3
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,26 +45,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.12"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
- "lazy_static",
+ "is-terminal",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -86,11 +73,32 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.1.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -105,12 +113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,21 +120,30 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
+ "windows-sys",
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.8.1"
+name = "is-terminal"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -142,16 +153,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "libc"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
-name = "libc"
-version = "0.2.124"
+name = "linux-raw-sys"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -161,6 +172,12 @@ checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os_str_bytes"
@@ -200,11 +217,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -214,6 +231,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -316,10 +347,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.0"
+name = "unicode-ident"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-xid"
@@ -363,3 +394,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cargo_metadata = "0.11.0"
-clap = { version = "3.1.12", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive"] }
 goblin = "0.2.3"
 serde = "1.0"
 serde_derive = "1.0"

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ cargo install --path .
 Note that `cargo`'s dependency resolver may behave differently when installing, and you may end up with errors.
 In order to fix those and force usage of the versions specified in the tagged `Cargo.lock`, append `--locked` to the above commands.
 
-### Setting up custom targets
-
-The preferred method is to have all custom target files (`nanos.json`, `nanox.json` and `nanosplus.json`) in a separate folder, and set an environment variable called `LEDGER_TARGETS` pointing to this folder.
-
-`cargo ledger` will check for this environment variable (or default to "" if it is empty) to fetch the current target specification.
-
 ## Usage
 
 
@@ -38,7 +32,9 @@ cargo ledger nanox
 cargo ledger nanosplus
 ```
 
-Loading can optionally be performed by appending `--load` or `-l` to the command.
+This command uses custom targets that are present in the Rust SDK. `cargo-ledger` will download them automatically if they are not present.
+
+Loading on device can optionally be performed by appending `--load` or `-l` to the command.
 
 By default, this program will attempt to build the current program with in `release` mode (full command: `cargo build -Zbuild-std -Zbuild-std-features=compiler-builtins-mem --release --target=nanos.json --message-format=json`)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 Builds a Nano App and outputs a JSON manifest file that can be used by [ledgerctl](https://github.com/LedgerHQ/ledgerctl) to install an application directly.
 
-In order to build for Nano S, Nano X, and Nano S Plus, [custom target files](https://docs.rust-embedded.org/embedonomicon/custom-target.html) are used. They can be found at the root of the [Rust SDK](https://github.com/LedgerHQ/ledger-nanos-sdk/).
+In order to build for Nano S, Nano X, and Nano S Plus, [custom target files](https://docs.rust-embedded.org/embedonomicon/custom-target.html) are used. They can be found at the root of the [Rust SDK](https://github.com/LedgerHQ/ledger-nanos-sdk/) and can be installed automatically with the command `setup`.
 
 ## Installation
 
-Only `arm-none-eabi-objcopy` is needed.
+This program requires:
+
+- `arm-none-eabi-objcopy`
+- [`ledgerctl`](https://github.com/LedgerHQ/ledgerctl)
 
 Install this repo with:
 
@@ -25,22 +28,30 @@ In order to fix those and force usage of the versions specified in the tagged `C
 
 ## Usage
 
+General usage is displayed when invoking `cargo ledger`.
+
+### Setup
+
+This will install custom target files from the SDK directly into your environment.
 
 ```
-cargo ledger nanos
-cargo ledger nanox
-cargo ledger nanosplus
+cargo ledger setup
 ```
 
-This command uses custom targets that are present in the Rust SDK. `cargo-ledger` will download them automatically if they are not present.
+### Building
+
+```
+cargo ledger build nanos
+cargo ledger build nanox
+cargo ledger build nanosplus
+```
 
 Loading on device can optionally be performed by appending `--load` or `-l` to the command.
 
-By default, this program will attempt to build the current program with in `release` mode (full command: `cargo build -Zbuild-std -Zbuild-std-features=compiler-builtins-mem --release --target=nanos.json --message-format=json`)
-
+By default, this program will attempt to build the current program with in `release` mode (full command: `cargo build --release --target=nanos --message-format=json`)
 
 Arguments can be passed to modify this behaviour after inserting a `--` like so:
 
 ```
-cargo ledger nanos --load -- --features one -Z unstable-options --out-dir ./output/
+cargo ledger build nanos --load -- --features one -Z unstable-options --out-dir ./output/
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,41 @@ enum MainCommand {
 }
 
 fn main() {
+    // Check if target files are installed
+    let sysroot_cmd = Command::new("rustc")
+        .arg("--print")
+        .arg("sysroot")
+        .output()
+        .expect("failed to call rustc")
+        .stdout;
+    let sysroot_cmd = std::str::from_utf8(&sysroot_cmd).unwrap().trim();
+
+    let target_files_url = Path::new(
+        "https://raw.githubusercontent.com/LedgerHQ/ledger-nanos-sdk/master/",
+    );
+    let sysroot = Path::new(sysroot_cmd).join("lib").join("rustlib");
+
+    // Retrieve each target file independently
+    // TODO: handle target.json modified upstream
+    for target in &["nanos", "nanox", "nanosplus"] {
+        let outfilepath = sysroot.join(target).join("target.json");
+        if !outfilepath.exists() {
+            let targetpath =
+                outfilepath.clone().into_os_string().into_string().unwrap();
+            println!("* Adding \x1b[1;32m{target}\x1b[0m in \x1b[1;33m{targetpath}\x1b[0m");
+
+            let target_url = target_files_url.join(format!("{target}.json"));
+            let cmd = Command::new("curl")
+                .arg(target_url)
+                .arg("-o")
+                .arg(outfilepath)
+                .arg("--create-dirs")
+                .output()
+                .expect("failed to execute 'curl'");
+            println!("{}", std::str::from_utf8(&cmd.stderr).unwrap());
+        }
+    }
+
     let cli = Cli::parse();
 
     let ledger_target_path = match env::var("LEDGER_TARGETS") {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,42 @@
+use std::path::Path;
+use std::process::Command;
+
+pub fn install_targets() {
+    println!("[ ] Checking for installed custom targets...");
+    // Check if target files are installed
+    let sysroot_cmd = Command::new("rustc")
+        .arg("--print")
+        .arg("sysroot")
+        .output()
+        .expect("failed to call rustc")
+        .stdout;
+    let sysroot_cmd = std::str::from_utf8(&sysroot_cmd).unwrap().trim();
+
+    let target_files_url = Path::new(
+        "https://raw.githubusercontent.com/LedgerHQ/ledger-nanos-sdk/master/",
+    );
+    let sysroot = Path::new(sysroot_cmd).join("lib").join("rustlib");
+
+    // Retrieve each target file independently
+    // TODO: handle target.json modified upstream
+    for target in &["nanos", "nanox", "nanosplus"] {
+        let outfilepath = sysroot.join(target).join("target.json");
+        if !outfilepath.exists() {
+            let targetpath =
+                outfilepath.clone().into_os_string().into_string().unwrap();
+            println!("* Adding \x1b[1;32m{target}\x1b[0m in \x1b[1;33m{targetpath}\x1b[0m");
+
+            let target_url = target_files_url.join(format!("{target}.json"));
+            let cmd = Command::new("curl")
+                .arg(target_url)
+                .arg("-o")
+                .arg(outfilepath)
+                .arg("--create-dirs")
+                .output()
+                .expect("failed to execute 'curl'");
+            println!("{}", std::str::from_utf8(&cmd.stderr).unwrap());
+        } else {
+            println!("* {target} already installed");
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the behaviour of `cargo-ledger` to always check whether the `nanos`, `nanox`, `nanosplus` custom target files from the Rust SDK are present in the rustup toolchain (the `rustc --print sysroot` folder). If they are not present, `cargo-ledger` will use `curl` to get them from the SDK's master branch.

After that, the targets are available to `cargo` from anywhere, with no need to point to a specific folder or use an environment variable, as was previously advised.

This works thanks to https://github.com/rust-lang/rust/pull/83800