### PR TITLE
Small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-/target
+# Editors
+.idea/
+.vscode/
+
+# Rust
+target

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
 
             exe_path
         }
-        Some(prebuilt) => prebuilt,
+        Some(prebuilt) => prebuilt.canonicalize().unwrap(),
     };
 
     // Fetch crate metadata without fetching dependencies
@@ -168,7 +168,7 @@ fn main() {
     // Retrieve real 'dataSize' from ELF
     let data_size = retrieve_data_size(&exe_path).unwrap();
 
-    // Modify flags to enable BLE if targetting Nano X
+    // Modify flags to enable BLE if targeting Nano X
     let flags = match device_str {
         "nanos" | "nanosplus" => this_metadata.flags,
         "nanox" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
     let this_pkg = res.packages.last().unwrap();
     let metadata_value = this_pkg
         .metadata
-        .get("nanos")
+        .get(device_str)
         .expect("package.metadata.nanos section is missing in Cargo.toml")
         .clone();
     let this_metadata: NanosMetadata =

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,11 +50,19 @@ pub fn install_with_ledgerctl(
     dir: &std::path::Path,
     app_json: &std::path::Path,
 ) {
-    let out = Command::new("ledgerctl")
-        .current_dir(dir)
-        .args(["install", "-f", app_json.to_str().unwrap()])
-        .output()
-        .expect("fail");
+    let out = if cfg!(target_os = "macos") {
+        Command::new("python3")
+            .current_dir(dir)
+            .args(["-m", "ledgerctl", "install", "-f", app_json.to_str().unwrap()])
+            .output()
+            .expect("fail")
+    } else {
+        Command::new("ledgerctl")
+            .current_dir(dir)
+            .args(["install", "-f", app_json.to_str().unwrap()])
+            .output()
+            .expect("fail")
+    };
 
     io::stdout().write_all(&out.stdout).unwrap();
     io::stderr().write_all(&out.stderr).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,19 +50,11 @@ pub fn install_with_ledgerctl(
     dir: &std::path::Path,
     app_json: &std::path::Path,
 ) {
-    let out = if cfg!(target_os = "macos") {
-        Command::new("python3")
-            .current_dir(dir)
-            .args(["-m", "ledgerctl", "install", "-f", app_json.to_str().unwrap()])
-            .output()
-            .expect("fail")
-    } else {
-        Command::new("ledgerctl")
-            .current_dir(dir)
-            .args(["install", "-f", app_json.to_str().unwrap()])
-            .output()
-            .expect("fail")
-    };
+    let out = Command::new("ledgerctl")
+        .current_dir(dir)
+        .args(["install", "-f", app_json.to_str().unwrap()])
+        .output()
+        .expect("fail");
 
     io::stdout().write_all(&out.stdout).unwrap();
     io::stderr().write_all(&out.stderr).unwrap();


### PR DESCRIPTION
This PR contains two fixes and two minor improvements:
- ~~fix: resolves the issue with invoking `ledgerctl` on macOS - the utility might not be available via PATH after install. Invoking it via `python3 -m` resolves the issue.~~ Seems this is specific to some versions of `ledgerctl` and should not be necessary in general.
- fix: device name should be used to retrieve section from the `Cargo.toml` (instead of hard-coded `nanos`).
- improvement: make cargo-ledger a little bit more convenient to use by enabling relative paths for pre-built binaries. 
- improvement: few more entries in `.gitignore` prevent adding IDE-specific files during commits.


