### PR TITLE
add new apilevel field

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use utils::*;
 
 #[derive(Debug, Deserialize)]
 struct NanosMetadata {
+    api_level: String,
     curve: Vec<String>,
     path: Vec<String>,
     flags: String,
@@ -199,6 +200,7 @@ fn main() {
             "curves": this_metadata.curve,
             "paths": this_metadata.path
         },
+        "apiLevel": this_metadata.api_level,
         "binary": hex_file,
         "dataSize": data_size
     });


### PR DESCRIPTION
Nano X v2.1.0 and Nano S+ v1.1.0 require a new "api_level" to be transmitted during loading. Although this level is implicitly defined by the underlying SDK, it was chosen to also define it as a 'minimum supported version' within apps' Cargo.toml