### PR TITLE
Feat/device testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "goblin",
+ "hex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -123,6 +124,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "io-lifetimes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "clap",
  "goblin",
  "hex",
+ "hidapi",
  "serde",
  "serde_derive",
  "serde_json",
@@ -132,6 +133,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hidapi"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7461dc5aae7f2f360289bae7d169690e51c182d4b5a56adeb8c7f312965f0411"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +204,12 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plain"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ cargo_metadata = "0.11.0"
 clap = { version = "4.1.8", features = ["derive"] }
 goblin = "0.2.3"
 hex = "0.4.3"
+hidapi = "2.2.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 cargo_metadata = "0.11.0"
 clap = { version = "4.1.8", features = ["derive"] }
 goblin = "0.2.3"
+hex = "0.4.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,22 +1,50 @@
+use clap::{ValueEnum};
+
 mod speculos;
 mod hid;
 mod interface;
 
 use interface::Backend;
-pub use speculos::SpeculosBackend;
-pub use hid::HidBackend;
+use speculos::SpeculosBackend;
+use hid::HidBackend;
 
-pub struct Comm<T: Backend> {
-    pipe: T,
+#[derive(ValueEnum, Clone, Debug)]
+pub enum BackendType {
+    Speculos,
+    Hid,
 }
 
-impl <T: Backend>Comm<T> {
-    pub fn create() -> Self {
-        let mut pipe = T::new();
-        pipe.open();
-        Comm {
-            pipe
+impl AsRef<str> for BackendType {
+    fn as_ref(&self) -> &str {
+        match self {
+            BackendType::Speculos => "speculos",
+            BackendType::Hid => "hid"
         }
+    }
+}
+
+pub struct Comm {
+    pipe: Box<dyn Backend>,
+}
+
+impl Comm {
+    pub fn create(backend: BackendType) -> Self {
+        let mut comm: Comm = match backend {
+            BackendType::Speculos => {
+                let pipe = SpeculosBackend::new();
+                Comm {
+                    pipe: Box::new(pipe)
+                }
+            }
+            BackendType::Hid => {
+                let pipe = HidBackend::new();
+                Comm {
+                    pipe: Box::new(pipe)
+                }
+            }
+        };
+        comm.pipe.open();
+        comm
     }
 
     pub fn exchange_apdu(&mut self, apdu: &[u8]) -> (Vec<u8>, [u8; 2]) {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2,7 +2,7 @@ mod speculos;
 mod hid;
 mod interface;
 
-pub use interface::Backend;
+use interface::Backend;
 pub use speculos::SpeculosBackend;
 pub use hid::HidBackend;
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,26 @@
+mod speculos;
+mod hid;
+mod interface;
+
+pub use interface::Backend;
+pub use speculos::SpeculosBackend;
+pub use hid::HidBackend;
+
+pub struct Comm<T: Backend> {
+    pipe: T,
+}
+
+impl <T: Backend>Comm<T> {
+    pub fn create() -> Self {
+        let mut pipe = T::new();
+        pipe.open();
+        Comm {
+            pipe
+        }
+    }
+
+    pub fn exchange_apdu(&mut self, apdu: &[u8]) -> (Vec<u8>, [u8; 2]) {
+        self.pipe.send(apdu).unwrap();
+        self.pipe.recv()
+    }
+}

--- a/src/backend/hid.rs
+++ b/src/backend/hid.rs
@@ -7,8 +7,8 @@ pub struct HidBackend {
     device: Option<HidDevice>
 }
 
-impl Backend for HidBackend {
-    fn new() -> Self {
+impl HidBackend {
+    pub fn new() -> Self {
         let api = hidapi::HidApi::new().unwrap();
         HidBackend {
             hid: api,
@@ -16,7 +16,9 @@ impl Backend for HidBackend {
             device: None
         }
     }
+}
 
+impl Backend for HidBackend {
     fn open(&mut self) {
 
         let device_info = self.hid.device_list().find(

--- a/src/backend/hid.rs
+++ b/src/backend/hid.rs
@@ -1,23 +1,118 @@
+use hidapi::{HidApi, DeviceInfo, HidDevice};
+
 use crate::backend::interface::Backend;
 pub struct HidBackend {
+    hid: HidApi,
+    device_info: Option<DeviceInfo>,
+    device: Option<HidDevice>
 }
 
 impl Backend for HidBackend {
     fn new() -> Self {
-        HidBackend { }
+        let api = hidapi::HidApi::new().unwrap();
+        HidBackend {
+            hid: api,
+            device_info: None,
+            device: None
+        }
     }
 
     fn open(&mut self) {
+
+        let device_info = self.hid.device_list().find(
+            |&device| device.vendor_id() == 0x2C97 && 
+            (device.interface_number() == 0 || device.usage_page() == 0xffa0));
+
+        match device_info {
+            Some(d) => {
+                self.device_info = Some(d.clone());
+                let device = d.open_device(&self.hid);
+                match device {
+                    Ok(d) => {
+                        d.set_blocking_mode(false).unwrap();
+                        self.device = Some(d);
+                    }
+                    Err(_e) => ()
+                }
+            },
+            None => ()
+        }
     }
 
-    fn close(&mut self) {
-    }
+    fn close(&mut self) {}
 
     fn send(&mut self, data: &[u8]) -> std::io::Result<usize> {
-        Ok(0)
+
+        let len: u16 = data.len() as u16;
+        let data_to_send = [&len.to_be_bytes()[..], data].concat(); 
+
+        let mut offset = 0;
+        let mut seq_idx: u16 = 0;
+        let mut header: Vec<u8>;
+        let zero: Vec<u8> = vec![0x00]; // report ID
+
+        match &self.device {
+            Some(device) => {
+                while offset < data_to_send.len() {
+                    // Header: channel (0x101), tag (0x05), sequence index
+                    let seq_idx_bytes = seq_idx.to_be_bytes(); 
+                    header = vec![0x01, 0x01, 0x05, seq_idx_bytes[0], seq_idx_bytes[1]];
+                    let chunk = [
+                        &zero[..], 
+                        &header[..], 
+                        &data_to_send[offset..std::cmp::min(offset + 64 - header.len(), data_to_send.len())]
+                    ].concat();
+                    match device.write(chunk.as_slice()) {
+                        Ok(_s) => (),
+                        Err(e) => {
+                            eprintln!("HID write error {}", e);
+                            return Ok(offset);
+                        }
+                    }
+                    offset += 64 - header.len();
+                    seq_idx += 1;
+                }
+                Ok(data.len())
+            }
+            None => {
+                eprintln!("No Ledger device");
+                Ok(0)
+            }
+        }
     }
 
     fn recv(&mut self) -> (Vec<u8>, [u8; 2]) {
-         (Vec::<u8>::new(), [0; 2])
+
+        let mut chunk: [u8; 65] = [0;65];
+
+        match &self.device {
+            Some(device) => {
+
+                device.set_blocking_mode(true).unwrap();
+                device.read(&mut chunk[..]).unwrap();
+                device.set_blocking_mode(false).unwrap();
+
+                let data_len: usize = (chunk[5] * 255) as usize + chunk[6] as usize;
+                
+                let mut data: Vec<u8> = Vec::new();
+                data.extend_from_slice(&chunk[7..std::cmp::min(64, 7 + data_len)]);
+
+                
+                while data.len() < data_len {
+                    device.read_timeout(&mut chunk[..], 1000).unwrap();
+                    data.extend_from_slice(&chunk[5..std::cmp::min(64, 5 + data_len - data.len())]);
+                }
+                
+                let mut sw: [u8; 2] = [0;2];
+                sw[1] = data.pop().unwrap();
+                sw[0] = data.pop().unwrap();
+                
+                (data, sw)
+            }
+            None => {
+                eprintln!("No Ledger device");
+                (Vec::new(), [0; 2])
+            }
+        }
     }
 }

--- a/src/backend/hid.rs
+++ b/src/backend/hid.rs
@@ -1,0 +1,23 @@
+use crate::backend::interface::Backend;
+pub struct HidBackend {
+}
+
+impl Backend for HidBackend {
+    fn new() -> Self {
+        HidBackend { }
+    }
+
+    fn open(&mut self) {
+    }
+
+    fn close(&mut self) {
+    }
+
+    fn send(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        Ok(0)
+    }
+
+    fn recv(&mut self) -> (Vec<u8>, [u8; 2]) {
+         (Vec::<u8>::new(), [0; 2])
+    }
+}

--- a/src/backend/interface.rs
+++ b/src/backend/interface.rs
@@ -1,0 +1,13 @@
+pub trait Backend {
+
+    fn new() -> Self;
+    
+    fn open(&mut self);
+
+    fn close(&mut self);
+
+    fn send(&mut self, data: &[u8]) -> std::io::Result<usize>;
+
+    fn recv(&mut self) -> (Vec<u8>, [u8; 2]);
+
+}

--- a/src/backend/interface.rs
+++ b/src/backend/interface.rs
@@ -1,6 +1,6 @@
 pub trait Backend {
 
-    fn new() -> Self;
+    //fn new() -> Self;
     
     fn open(&mut self);
 

--- a/src/backend/speculos.rs
+++ b/src/backend/speculos.rs
@@ -13,11 +13,13 @@ pub struct SpeculosBackend {
     pub stream: Option<TcpStream>
 }
 
-impl Backend for SpeculosBackend {
-    fn new() -> Self {
+impl SpeculosBackend {
+    pub fn new() -> Self {
         SpeculosBackend { server: String::from(DEFAULT_SPECULOS_PROXY_ADDRESS), port: DEFAULT_SPECULOS_PROXY_PORT, stream: None }
     }
+}
 
+impl Backend for SpeculosBackend {
     fn open(&mut self) {
         if let Ok(stream) = TcpStream::connect((self.server.as_str(), self.port)) {
             self.stream = Some(stream);

--- a/src/backend/speculos.rs
+++ b/src/backend/speculos.rs
@@ -34,7 +34,6 @@ impl Backend for SpeculosBackend {
     fn send(&mut self, data: &[u8]) -> std::io::Result<usize> {
         match &mut self.stream {
             Some(s) => {
-                println!("sending data");
                 let mut data_to_send: Vec<u8> = Vec::from(data.len().to_be_bytes());
                 data_to_send.append(&mut Vec::from(data));
                 s.write(data_to_send.as_slice())

--- a/src/backend/speculos.rs
+++ b/src/backend/speculos.rs
@@ -1,0 +1,65 @@
+use std::{net::{TcpStream, Shutdown}};
+use std::io::{Read, Write};
+use std::convert::TryInto;
+
+use crate::backend::interface::Backend;
+
+const DEFAULT_SPECULOS_PROXY_ADDRESS: &str = "127.0.0.1";
+const DEFAULT_SPECULOS_PROXY_PORT: u16 = 9999;
+
+pub struct SpeculosBackend {
+    pub server: String,
+    pub port: u16,
+    pub stream: Option<TcpStream>
+}
+
+impl Backend for SpeculosBackend {
+    fn new() -> Self {
+        SpeculosBackend { server: String::from(DEFAULT_SPECULOS_PROXY_ADDRESS), port: DEFAULT_SPECULOS_PROXY_PORT, stream: None }
+    }
+
+    fn open(&mut self) {
+        if let Ok(stream) = TcpStream::connect((self.server.as_str(), self.port)) {
+            self.stream = Some(stream);
+        }
+    }
+
+    fn close(&mut self) {
+        match &self.stream {
+            Some(s) => s.shutdown(Shutdown::Both).unwrap(),
+            None => (),
+        }
+    }
+
+    fn send(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        match &mut self.stream {
+            Some(s) => {
+                println!("sending data");
+                let mut data_to_send: Vec<u8> = Vec::from(data.len().to_be_bytes());
+                data_to_send.append(&mut Vec::from(data));
+                s.write(data_to_send.as_slice())
+            }
+            None => Ok(0),
+        }
+    }
+
+    fn recv(&mut self) -> (Vec<u8>, [u8; 2]) {
+        match &mut self.stream {
+            Some(s) => {
+                let mut data_size = [0; 4];
+                s.read_exact(&mut data_size).unwrap();
+                let size = u32::from_be_bytes(data_size.try_into().unwrap());
+
+                let mut data: Vec<u8>=  vec![0; size as usize];
+                s.read(&mut data).unwrap();
+
+                let mut sw = [0; 2];
+                s.read(&mut sw).unwrap();
+
+                (data, sw)
+            }    
+            None => (Vec::<u8>::new(), [0; 2])
+        }
+    }
+
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,14 +126,7 @@ fn main() {
                     let mut buf: String = String::new();
                     file.read_to_string(&mut buf).unwrap();
 
-                    let mut comm: Comm = match b {
-                        BackendType::Speculos => {
-                            Comm::create(BackendType::Speculos)
-                        }
-                        BackendType::Hid => {
-                            Comm::create(BackendType::Hid)
-                        }
-                    };
+                    let mut comm: Comm = Comm::create(b);
                     
                     for r in buf.lines() {
                         println!("=> {}", r);

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,16 +129,23 @@ fn main() {
                     let mut comm: Comm = Comm::create(b);
                     
                     for r in buf.lines() {
-                        println!("=> {}", r);
-                        let apdu = hex::decode(r).unwrap();
-                        let (data_recv, sw) = comm.exchange_apdu(apdu.as_slice());
-                        print!("<= ");
-                        for b in data_recv {
-                            print!("{:02x}", b);
-                        }
-                        println!(" {:02x}{:02x}", sw[0], sw[1]);
-                        if u16::from_be_bytes(sw) != SW_OK {
-                            break;
+                        match r.starts_with("=> ") {
+                            true => {
+                                println!("{}", r);
+                                let apdu = hex::decode(r.strip_prefix("=> ").unwrap()).unwrap();
+                                let (data_recv, sw) = comm.exchange_apdu(apdu.as_slice());
+                                print!("<= ");
+                                for b in data_recv {
+                                    print!("{:02x}", b);
+                                }
+                                println!(" {:02x}{:02x}", sw[0], sw[1]);
+                                if u16::from_be_bytes(sw) != SW_OK {
+                                    break;
+                                }
+                            }
+                            false => {
+                                println!("UNSENT: {} (only apdu prefixed with '=> ' are sent)", r);
+                            }
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,19 @@ enum MainCommand {
     },
 }
 
+enum Back {
+    Speculos(Comm::<backend::SpeculosBackend>),
+    Hid(Comm::<backend::HidBackend>)
+}
+
+impl Back {
+    fn exchange_apdu(&mut self, apdu: &[u8]) {
+        match self {
+            Back::Speculos(x) => x.exchange_apdu(apdu),
+            Back::Hid(x) => x.exchange_apdu(apdu),
+        };
+    }
+}
 
 fn main() {
     let Cli::Ledger(cli) = Cli::parse();
@@ -140,13 +153,12 @@ fn main() {
                     let mut buf: String = String::new();
                     file.read_to_string(&mut buf);
 
-
                     let mut comm = match b {
                         Backend::Speculos => {
-                            Comm::<backend::SpeculosBackend>::create() 
+                            Back::Speculos(Comm::<backend::SpeculosBackend>::create())
                         }
                         Backend::Hid => {
-                            Comm::<backend::HidBackend>::create()
+                            Back::Hid(Comm::<backend::HidBackend>::create())
                         }
                     };
 


### PR DESCRIPTION
Added a new command in cargo-ledger to be able to test Ledger device (speculos or hw device):

```
cargo ledger send --help
send apdus to app running in speculos env or in hw device

Usage: cargo ledger send [FILE] [BACKEND]

Arguments:
  [FILE]     file to read apdus from
  [BACKEND]  backend to use [default: speculos] [possible values: speculos, hid]

Options:
  -h, --help  Print help
```