### PR TITLE
Various enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-/target
+# Editors
+.idea/
+.vscode/
+
+# Rust
+target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ledger"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["yhql"]
 description = "Build and sideload Ledger Nano apps"
 categories = ["development-tools::cargo-plugins"]


### PR DESCRIPTION
- Support per-device section in Cargo.toml with fallback to NanoS if device-specific version is missing (for backward compatibility)
- Enable use of relative paths for pre-built binaries
- Add .gitignore file to repo
- Bump version to distinguish the updated version from the original one