### PR TITLE
Metadata update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-/target
+# Editors
+.idea/
+.vscode/
+
+# Rust
+target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,56 @@
 version = 3
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "anstream"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
 
 [[package]]
 name = "cargo-ledger"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -32,74 +74,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "is-terminal",
- "once_cell",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
-name = "errno"
-version = "0.2.8"
+name = "colorchoice"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "goblin"
@@ -114,76 +132,21 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
- "windows-sys",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
-
-[[package]]
-name = "libc"
-version = "0.2.140"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "plain"
@@ -192,66 +155,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rustix"
-version = "0.36.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scroll"
@@ -270,7 +195,7 @@ checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -291,29 +216,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -328,87 +253,52 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
+name = "syn"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
- "winapi-util",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -421,42 +311,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ledger"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["yhql"]
 description = "Build and sideload Ledger Nano apps"
 categories = ["development-tools::cargo-plugins"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ledger"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["yhql"]
 description = "Build and sideload Ledger Nano apps"
 categories = ["development-tools::cargo-plugins"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
 
-use cargo_metadata::Message;
+use cargo_metadata::{Message, Package};
 use clap::{Parser, Subcommand, ValueEnum};
 use serde_derive::Deserialize;
 use serde_json::json;
@@ -15,6 +15,8 @@ use utils::*;
 mod setup;
 mod utils;
 
+/// Structure for retrocompatibility, when the cargo manifest file
+/// contains a single `[package.metadata.nanos]` section
 #[derive(Debug, Deserialize)]
 struct NanosMetadata {
     curve: Vec<String>,
@@ -23,6 +25,19 @@ struct NanosMetadata {
     icon: String,
     icon_small: String,
     name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LedgerMetadata {
+    curve: Vec<String>,
+    path: Vec<String>,
+    flags: String,
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceMetadata {
+    icon: String,
 }
 
 #[derive(Parser, Debug)]
@@ -53,7 +68,7 @@ struct CliArgs {
     command: MainCommand,
 }
 
-#[derive(ValueEnum, Clone, Debug, PartialEq)]
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq)]
 enum Device {
     Nanos,
     Nanox,
@@ -108,6 +123,68 @@ fn main() {
     }
 }
 
+fn retrieve_metadata(
+    device: Device,
+    manifest_path: Option<&str>,
+) -> (Package, LedgerMetadata, DeviceMetadata) {
+    let mut cmd = cargo_metadata::MetadataCommand::new();
+
+    // Only used during tests
+    if let Some(manifestpath) = manifest_path {
+        cmd = cmd.manifest_path(manifestpath).clone();
+    }
+
+    let res = cmd
+        .no_deps()
+        .exec()
+        .expect("Could not execute `cargo metadata`");
+
+    let this_pkg = res.packages.last().unwrap();
+    let metadata_section = this_pkg.metadata.get("ledger");
+
+    if let Some(metadatasection) = metadata_section {
+        let metadata_device = metadata_section
+            .unwrap()
+            .clone()
+            .get(device.as_ref())
+            .unwrap()
+            .clone();
+
+        let ledger_metadata: LedgerMetadata =
+            serde_json::from_value(metadatasection.clone())
+                .expect("Could not deserialize medatada.ledger");
+        let device_metadata: DeviceMetadata =
+            serde_json::from_value(metadata_device)
+                .expect("Could not deserialize device medatada");
+
+        (this_pkg.clone(), ledger_metadata, device_metadata)
+    } else {
+        println!("WARNING: 'package.metadata.ledger' section is missing in Cargo.toml, trying 'package.metadata.nanos'");
+        let nanos_section = this_pkg.metadata.get("nanos").expect(
+            "No appropriate [package.metadata.<ledger|nanos>] section found.",
+        );
+
+        let nanos_metadata: NanosMetadata =
+            serde_json::from_value(nanos_section.clone())
+                .expect("Could not deserialize medatada.nanos");
+        let ledger_metadata = LedgerMetadata {
+            curve: nanos_metadata.curve,
+            path: nanos_metadata.path,
+            flags: nanos_metadata.flags,
+            name: nanos_metadata.name,
+        };
+
+        let device_metadata = DeviceMetadata {
+            icon: match device {
+                Device::Nanos => nanos_metadata.icon,
+                _ => nanos_metadata.icon_small,
+            },
+        };
+
+        (this_pkg.clone(), ledger_metadata, device_metadata)
+    }
+}
+
 fn build_app(
     device: Device,
     is_load: bool,
@@ -153,29 +230,12 @@ fn build_app(
         Some(prebuilt) => prebuilt.canonicalize().unwrap(),
     };
 
-    // Fetch crate metadata without fetching dependencies
-    let mut cmd = cargo_metadata::MetadataCommand::new();
-    let res = cmd.no_deps().exec().unwrap();
-
-    // Fetch package.metadata.(nanos|nanosplus|nanox) section
-    let this_pkg = res.packages.last().unwrap();
-    let metadata_value = this_pkg
-        .metadata
-        .get(device.as_ref())
-        .or_else(|| {
-            if device != Device::Nanos {
-                println!("WARNING: 'package.metadata.{device}' section is missing in Cargo.toml, trying 'package.metadata.nanos'");
-                this_pkg.metadata.get("nanos")
-            } else {
-                None
-            }
-        })
-        .expect("package.metadata.nanos section is missing in Cargo.toml")
-        .clone();
-    let this_metadata: NanosMetadata =
-        serde_json::from_value(metadata_value).unwrap();
-
-    let current_dir = this_pkg.manifest_path.parent().unwrap();
+    let (this_pkg, metadata_ledger, metadata_device) =
+        retrieve_metadata(device, None);
+    let current_dir = this_pkg
+        .manifest_path
+        .parent()
+        .expect("Could not find package's parent path");
 
     let hex_file_abs = if hex_next_to_json {
         current_dir
@@ -198,32 +258,32 @@ fn build_app(
 
     // Modify flags to enable BLE if targeting Nano X
     let flags = match device {
-        Device::Nanos | Device::Nanosplus => this_metadata.flags,
+        Device::Nanos | Device::Nanosplus => metadata_ledger.flags,
         Device::Nanox => {
-            let base = u32::from_str_radix(this_metadata.flags.as_str(), 16)
+            let base = u32::from_str_radix(metadata_ledger.flags.as_str(), 16)
                 .unwrap_or(0);
             format!("0x{:x}", base | 0x200)
         }
     };
 
     // Pick icon and targetid according to target
-    let (targetid, icon) = match device {
-        Device::Nanos => ("0x31100004", &this_metadata.icon),
-        Device::Nanox => ("0x33000004", &this_metadata.icon_small),
-        Device::Nanosplus => ("0x33100004", &this_metadata.icon_small),
+    let targetid = match device {
+        Device::Nanos => "0x31100004",
+        Device::Nanox => "0x33000004",
+        Device::Nanosplus => "0x33100004",
     };
 
     // create manifest
     let file = fs::File::create(&app_json).unwrap();
     let mut json = json!({
-        "name": this_metadata.name.as_ref().unwrap_or(&this_pkg.name),
+        "name": metadata_ledger.name.as_ref().unwrap_or(&this_pkg.name),
         "version": &this_pkg.version,
-        "icon": icon,
+        "icon": metadata_device.icon,
         "targetId": targetid,
         "flags": flags,
         "derivationPath": {
-            "curves": this_metadata.curve,
-            "paths": this_metadata.path
+            "curves": metadata_ledger.curve,
+            "paths": metadata_ledger.path
         },
         "binary": hex_file,
         "dataSize": infos.size
@@ -239,5 +299,51 @@ fn build_app(
 
     if is_load {
         install_with_ledgerctl(current_dir, &app_json);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_metadata() {
+        let (_, metadata_ledger, metadata_nanos) =
+            retrieve_metadata(Device::Nanos, Some("./tests/valid/Cargo.toml"));
+
+        assert_eq!(metadata_ledger.name, Some("TestApp".to_string()));
+        assert_eq!(metadata_ledger.curve, ["secp256k1"]);
+        assert_eq!(metadata_ledger.flags, "0x38");
+        assert_eq!(metadata_ledger.path, ["'44/123"]);
+
+        assert_eq!(metadata_nanos.icon, "./assets/nanos.gif")
+    }
+
+    #[test]
+    fn valid_metadata_variant() {
+        let (_, metadata_ledger, metadata_nanos) = retrieve_metadata(
+            Device::Nanos,
+            Some("./tests/valid_variant/Cargo.toml"),
+        );
+
+        assert_eq!(metadata_ledger.name, Some("TestApp".to_string()));
+        assert_eq!(metadata_ledger.curve, ["secp256k1"]);
+        assert_eq!(metadata_ledger.flags, "0x38");
+        assert_eq!(metadata_ledger.path, ["'44/123"]);
+        assert_eq!(metadata_nanos.icon, "./assets/nanos.gif")
+    }
+
+    #[test]
+    fn valid_outdated_metadata() {
+        let (_, metadata_ledger, metadata_nanos) = retrieve_metadata(
+            Device::Nanos,
+            Some("./tests/valid_outdated/Cargo.toml"),
+        );
+
+        assert_eq!(metadata_ledger.name, Some("TestApp".to_string()));
+        assert_eq!(metadata_ledger.curve, ["secp256k1"]);
+        assert_eq!(metadata_ledger.flags, "0");
+        assert_eq!(metadata_ledger.path, ["'44/123"]);
+        assert_eq!(metadata_nanos.icon, "nanos.gif")
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,9 @@ pub fn retrieve_infos(
     // in various `.ledger.<field_name>` section of the binary.
     // For now we only need the API_LEVEL
     for section in elf.section_headers.iter() {
-        if let Some(Ok(".ledger.api_level")) = elf.shdr_strtab.get(section.sh_name) { 
+        if let Some(Ok(".ledger.api_level")) =
+            elf.shdr_strtab.get(section.sh_name)
+        {
             infos.api_level = buffer[section.sh_offset as usize];
         }
     }

--- a/tests/valid/Cargo.toml
+++ b/tests/valid/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[[bin]]
+name = "test"
+path = ""
+
+[package.metadata.ledger]
+name = "TestApp"
+curve = ["secp256k1"]
+flags = "0x38"
+path = ["'44/123"]
+
+[package.metadata.ledger.nanos]
+icon = "./assets/nanos.gif"
+
+[package.metadata.ledger.nanox]
+icon = "./assets/nanox.gif"
+
+[package.metadata.ledger.nanosplus]
+icon = "./assets/nanosplus.gif"

--- a/tests/valid_outdated/Cargo.toml
+++ b/tests/valid_outdated/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[[bin]]
+name = "test"
+path = ""
+
+[package.metadata.nanos]
+api_level = "1"
+name = "TestApp"
+curve = ["secp256k1"]
+flags = "0"
+icon = "nanos.gif"
+icon_small = "nanox.gif"
+path = ["'44/123"]

--- a/tests/valid_variant/Cargo.toml
+++ b/tests/valid_variant/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[[bin]]
+name = "test"
+path = ""
+
+[package.metadata.ledger]
+name = "TestApp"
+curve = ["secp256k1"]
+flags = "0x38"
+path = ["'44/123"]
+nanos.icon = "./assets/nanos.gif"
+nanox.icon = "./assets/nanox.gif"
+nanosplus.icon = "./assets/nanosplus.gif"


### PR DESCRIPTION
Switch to a Cargo.toml metadata section that allows to specify device-specific options in a more convenient way, using @siy 's modifications as a basis. A main `metadata.ledger` section is declared that specifies all parameters that are device independent (curves, flags, derivation path, ...) and the icon has to be specified in another device specific section.

We now propose to use the following format, which has a variant (as can be seen in `tests/valid/Cargo.toml` and `tests/valid_variant/Cargo.toml`:

```toml
[package.metadata.ledger]
name = "TestApp"
curve = ["secp256k1"]
flags = "0x38"
path = ["'44/123"]

[package.metadata.ledger.nanos]
icon = "./assets/nanos.gif"

[package.metadata.ledger.nanox]
icon = "./assets/nanox.gif"

[package.metadata.ledger.nanosplus]
icon = "./assets/nanosplus.gif"
```

which is equivalent to

```toml
[package.metadata.ledger]
name = "TestApp"
curve = ["secp256k1"]
flags = "0x38"
path = ["'44/123"]
nanos.icon = "./assets/nanos.gif"
nanox.icon = "./assets/nanox.gif"
nanosplus.icon = "./assets/nanosplus.gif"
```

Retrocompatibility is ensured with projects that only declared the now-outdated `[package.metadata.nanos]` section