### PR TITLE
Fix api_level extraction for binaries compiled with new SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ledger"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["yhql"]
 description = "Build and sideload Ledger Nano apps"
 categories = ["development-tools::cargo-plugins"]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,6 +27,11 @@ pub fn retrieve_infos(
         {
             infos.api_level = buffer[section.sh_offset as usize];
         }
+        if let Some(Ok("ledger.api_level")) =
+            elf.shdr_strtab.get(section.sh_name)
+        {
+            infos.api_level = buffer[section.sh_offset as usize] - b'0';
+        }
     }
 
     let mut nvram_data = 0;


### PR DESCRIPTION
The [new SDK](https://github.com/LedgerHQ/ledger-device-rust-sdk/) changed section names for meta information (API level, SDK version, etc.) and this results in incorrectly generated JSON for devices other than Nano S. The section content format also changed from binary to ASCII char.
Fix provided in this PR enables processing of binaries compiled with new SDK.